### PR TITLE
fix: splice usage when toggling single item

### DIFF
--- a/src/app/components/ionic-selectable/ionic-selectable.component.ts
+++ b/src/app/components/ionic-selectable/ionic-selectable.component.ts
@@ -1644,7 +1644,7 @@ export class IonicSelectableComponent implements ControlValueAccessor, OnInit, D
 
         // Take the first item for single mode.
         if (!this.isMultiple) {
-          itemsToToggle.splice(0, 1);
+          itemsToToggle.splice(1);
         }
       }
 


### PR DESCRIPTION
The previous usage of [Array.splice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) was removing one item from the start of the array.

This pull-request fixes the `splice` arguments in order to only keep the first item (which matches the comment "Take the first item for single mode").

